### PR TITLE
Use default parameters for client functions

### DIFF
--- a/examples/TestClientCustomConfig/main.cpp
+++ b/examples/TestClientCustomConfig/main.cpp
@@ -19,18 +19,22 @@ std::string dumpClientConfigToString(const UA_ClientConfig* config)
     std::string result;
 
     result += "UA_ClientConfig {\n";
-    result += "\ttimeout = " + to_string(config->timeout) + "ms\n";
-    result += "\tsecureChannelLifeTime = " + to_string(config->secureChannelLifeTime) + "ms\n";
-    result += "\trequestedSessionTimeout = " + to_string(config->requestedSessionTimeout) + "ms\n";
-    result += "\tsecurityPoliciesSize = " + to_string(config->securityPoliciesSize) + "\n";
+    result += "\t timeout = " + to_string(config->timeout) + "ms\n";
+    result += "\t secureChannelLifeTime = " + to_string(config->secureChannelLifeTime) + "ms\n";
+    result += "\t requestedSessionTimeout = " + to_string(config->requestedSessionTimeout) + "ms\n";
+    result += "\t securityPoliciesSize = " + to_string(config->securityPoliciesSize) + "\n";
     if (config->securityPoliciesSize > 0)
-        result += "\tsecurityPolicies->policyUri = " + UAString2String(config->securityPolicies[0].policyUri) + "\n";
+        for (size_t i = 0; i < config->securityPoliciesSize; i++)
+            result += "\t securityPolicies->policyUri[" + to_string(i) + "] = "
+                   + UAString2String(config->securityPolicies[i].policyUri) + "\n";
     // result += "\tsecurityPolicies->localCertificate = " + UAString2String(config->securityPolicies->localCertificate)
     // + "\n";
-    result += "\tapplicationUri = " + UAString2String(config->applicationUri) + "\n";
-    result += "\tsecurityPolicyUri = " + UAString2String(config->securityPolicyUri) + "\n";
-    result += "\toutStandingPublishRequests = " + to_string(config->outStandingPublishRequests) + "\n";
-    result += "\tsessionLocaleIdsSize = " + to_string(config->sessionLocaleIdsSize) + "\n";
+    result +=
+        "\t clientDescription.applicationUri = " + UAString2String(config->clientDescription.applicationUri) + "\n";
+    result += "\t applicationUri = " + UAString2String(config->applicationUri) + "\n";
+    result += "\t securityPolicyUri = " + UAString2String(config->securityPolicyUri) + "\n";
+    result += "\t outStandingPublishRequests = " + to_string(config->outStandingPublishRequests) + "\n";
+    result += "\t sessionLocaleIdsSize = " + to_string(config->sessionLocaleIdsSize) + "\n";
     result += "}\n";
 
     return result;
@@ -80,8 +84,7 @@ int main()
     // cout << "Custom applicationUri: " << UAString2String(applicationUri) << endl;
     // clientConfig->applicationUri = applicationUri;
 
-    cout << "\n# Custom client config: " << dumpClientConfigToString(clientConfig) << endl;
-
+    cout << "\n# Using client config: " << dumpClientConfigToString(client.getConfig()) << endl;
     cout << "setCustomConfig..." << endl << endl;
     client.setCustomConfig(clientConfig);
 

--- a/examples/TestClientDefaultEncryption/CMakeLists.txt
+++ b/examples/TestClientDefaultEncryption/CMakeLists.txt
@@ -1,0 +1,9 @@
+project("Open62541Cpp")
+cmake_minimum_required(VERSION 3.11)
+# Build TestClientDefaultEncryption
+set(APPNAME TestClientDefaultEncryption)
+
+# Source code
+set(SOURCES main.cpp)
+
+include(../examples_common.cmake)

--- a/examples/TestClientDefaultEncryption/main.cpp
+++ b/examples/TestClientDefaultEncryption/main.cpp
@@ -1,0 +1,186 @@
+#include <iostream>
+//
+#include <open62541cpp/open62541client.h>
+#include <open62541cpp/clientsubscription.h>
+#include <open62541cpp/monitoreditem.h>
+//
+using namespace std;
+
+std::string UAString2String(const UA_String s)
+{
+    // cout << "str_lenght: " << s.length << endl;
+    std::string result((char*)s.data, s.length);
+    // cout << "str: " << result << endl;
+    return result;
+}
+
+std::string dumpClientConfigToString(const UA_ClientConfig* config)
+{
+    std::string result;
+
+    result += "UA_ClientConfig {\n";
+    result += "\t timeout = " + to_string(config->timeout) + "ms\n";
+    result += "\t secureChannelLifeTime = " + to_string(config->secureChannelLifeTime) + "ms\n";
+    result += "\t requestedSessionTimeout = " + to_string(config->requestedSessionTimeout) + "ms\n";
+    result += "\t securityPoliciesSize = " + to_string(config->securityPoliciesSize) + "\n";
+    if (config->securityPoliciesSize > 0)
+        for (size_t i = 0; i < config->securityPoliciesSize; i++)
+            result += "\t securityPolicies->policyUri[" + to_string(i) + "] = "
+                   + UAString2String(config->securityPolicies[i].policyUri) + "\n";
+    // result += "\tsecurityPolicies->localCertificate = " + UAString2String(config->securityPolicies->localCertificate)
+    // + "\n";
+
+
+
+    result +=
+        "\t clientDescription.applicationUri = " + UAString2String(config->clientDescription.applicationUri) + "\n";
+    result += "\t applicationUri = " + UAString2String(config->applicationUri) + "\n";
+    result += "\t securityPolicyUri = " + UAString2String(config->securityPolicyUri) + "\n";
+    result += "\t outStandingPublishRequests = " + to_string(config->outStandingPublishRequests) + "\n";
+    result += "\t sessionLocaleIdsSize = " + to_string(config->sessionLocaleIdsSize) + "\n";
+    result += "}\n";
+
+    return result;
+}
+
+/* loadFile parses the certificate file.
+ *
+ * @param  path               specifies the file name given in argv[]
+ * @return Returns the file content after parsing */
+static UA_INLINE UA_ByteString loadFile(std::string filepath)
+{
+    UA_ByteString fileContents = UA_STRING_NULL;
+
+    /* Open the file */
+    FILE* fp = fopen(filepath.c_str(), "rb");
+    if (!fp) {
+        errno = 0; /* We read errno also from the tcp layer... */
+        return fileContents;
+    }
+
+    /* Get the file length, allocate the data and read */
+    fseek(fp, 0, SEEK_END);
+    fileContents.length = (size_t)ftell(fp);
+    fileContents.data   = (UA_Byte*)UA_malloc(fileContents.length * sizeof(UA_Byte));
+    if (fileContents.data) {
+        fseek(fp, 0, SEEK_SET);
+        size_t read = fread(fileContents.data, sizeof(UA_Byte), fileContents.length, fp);
+        if (read != fileContents.length)
+            UA_ByteString_clear(&fileContents);
+    }
+    else {
+        fileContents.length = 0;
+    }
+    fclose(fp);
+
+    return fileContents;
+}
+
+/* Define a custom logger */
+void customLogger(void* context, UA_LogLevel level, UA_LogCategory category, const char* msg, va_list args)
+{
+    // FIXME : Also make use of UA_LogLevel
+    std::string buffer;
+    int n = vsnprintf(NULL, 0, msg, args);
+    if (n > 0) {
+        buffer.resize(n);
+        vsnprintf(buffer.data(), n + 1, msg, args);
+    }
+    cout << " (!)_LOG: " << buffer << endl;
+}
+
+int main()
+{
+    cout << "Client Subscription Test - (TestServer must be running)" << endl;
+    Open62541::Client client;
+
+    cout << "Initialising client with no configuration" << endl;
+    client.initialise(false);
+
+    cout << "Getting client config..." << endl;
+    UA_ClientConfig* clientConfig = client.getConfig();
+
+    // cout << "\n# Initial client config: " << dumpClientConfigToString(client.getConfig()) << endl;
+
+    cout << "Redirecting output stream..." << endl;
+    // Create a function pointer to the myLogger function
+    Open62541::Client::LoggerFuncPtr customLoggerFunction = &customLogger;
+    // Create a UA_Logger structure with the custom log function
+    UA_Logger customLogger = (UA_Logger){
+        .log     = customLoggerFunction,         //
+        .clear   = clientConfig->logger.clear,   //
+        .context = clientConfig->logger.context  //
+    };
+    // Set the clientConfig logger to use the customLogger
+    // clientConfig->logger = customLogger;
+    cout << "Redirecting output stream...done" << endl;
+
+
+    // cout << "setCustomConfig..." << endl << endl;
+    // client.setCustomConfig(clientConfig);
+
+    auto serverAddress = "opc.tcp://localhost:4840";  // TestServer
+
+    std::string username = "*****"; // FIXME : from parameter
+    std::string password = "*****"; // FIXME : from parameter
+    cout << "\t username= " << username << endl;
+    cout << "\t password= " << password << endl;
+
+    std::string certfile, keyfile;
+    certfile = "~/client_certificate.der"; // FIXME : from parameter
+    keyfile  = "~/client_private_key.pem"; // FIXME : from parameter
+    printf("Reading certfile=%s \n", certfile.c_str());
+    printf("Reading keyfile=%s \n", keyfile.c_str());
+    UA_ByteString certificate = loadFile(certfile);
+    UA_ByteString privateKey  = loadFile(keyfile);
+
+    printf("\n\t UA_ClientConfig_setDefaultEncryption..... \n");
+    UA_ClientConfig_setDefaultEncryption(clientConfig, certificate, privateKey, NULL, 0, NULL, 0);
+    UA_CertificateVerification_AcceptAll(&clientConfig->certificateVerification);
+    UA_ByteString_clear(&certificate);
+    UA_ByteString_clear(&privateKey);
+
+    UA_String securityPolicyUri         = UA_STRING_NULL;
+    UA_MessageSecurityMode securityMode = UA_MESSAGESECURITYMODE_INVALID; /* allow everything */
+    // clientConfig->securityMode      = securityMode; // FIXME : from parameter
+    clientConfig->securityMode = UA_MESSAGESECURITYMODE_SIGNANDENCRYPT;
+    // clientConfig->securityPolicyUri = securityPolicyUri; // FIXME : from parameter
+    clientConfig->securityPolicyUri = UA_String_fromChars("http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256");
+
+    /* The application URI must be the same as the one in the certificate.
+     * The script for creating a self-created certificate generates a certificate
+     * with the Uri specified below.*/
+    UA_ApplicationDescription_clear(&clientConfig->clientDescription);
+    clientConfig->clientDescription.applicationUri  = UA_STRING_ALLOC("urn:freeopcua:client");
+    clientConfig->clientDescription.applicationType = UA_APPLICATIONTYPE_CLIENT;
+
+    cout << "\n# Using client config: " << dumpClientConfigToString(client.getConfig()) << endl;
+
+    cout << "Connecting...." << endl;
+    // if (client.connect(serverAddress, false)) {
+    if (client.connectUsername(serverAddress, username, password, false)) {
+        // int idx = client.namespaceGetIndex("urn:test:test");
+        cout << "\n# Connected client config: " << dumpClientConfigToString(client.getConfig()) << endl;
+        // if (idx > 1) {
+        // cout << "Connected" << endl;
+        UA_UInt32 subId = 0;
+        if (client.addSubscription(subId)) {
+            cout << "Subscription Created id = " << subId << endl;
+            cout << "iterating..." << endl;
+            client.runIterate();
+            exit(-1);
+            // client.run();  // this will loop until interrupted
+        }
+        else {
+            cout << "Subscription Failed" << endl;
+        }
+        // }
+        // else {
+        //     cout << "TestServer not running idx = " << idx << endl;
+        // }
+    }
+    else {
+        cout << "Subscription Failed" << endl;
+    }
+    return 0;
+}

--- a/examples/TestServer/main.cpp
+++ b/examples/TestServer/main.cpp
@@ -59,6 +59,11 @@ void TestServer::initialise()
         Open62541::Variant numberValue(v);
         cout << "_repeatedEvent called setting number value = " << v << endl;
         s.server()->writeValue(nodeNumber, numberValue);
+
+        // Check the boolean value
+        // Open62541::NodeId nodeB(_idx, "BOOLEAN_Value");
+        // Open62541::Variant booleanVarian;
+        // s.server()->readValue(nodeB, booleanVarian);
     });
 
     // Add one shot timer
@@ -88,7 +93,7 @@ void TestServer::initialise()
             cout << "Failed to set value callback" << endl;
         }
     }
-    
+
    //Example adding an array by setting it with setArrayCopy
     Open62541::NodeId setArrayCopy_array_id(_idx, "Array_By_Copy");
     UA_Double setArrayCopy_temp_array[4] = {1.0, 2.0, 3.0, 4.0};
@@ -108,7 +113,7 @@ void TestServer::initialise()
     setArray_variant.setArray(setArray_array , setArray_array_size, &UA_TYPES[UA_TYPES_DOUBLE]);
     addVariable(setArrayCopy_array_id, "Array_By_Set", setArray_variant , setArray_array_id, Open62541::NodeId::Null);
 
-    //Example adding a matrix 
+    //Example adding a matrix
     Open62541::NodeId test_matrix_id(_idx, "Matrix_Example");
     Open62541::VariableAttributes vattr;
     Open62541::Variant vattr_value;
@@ -133,6 +138,20 @@ void TestServer::initialise()
     Open62541::Variant numberValue(1);
     if (!addVariable(Open62541::NodeId::Objects, "Number_Value", numberValue, nodeNumber, Open62541::NodeId::Null)) {
         cout << "Failed to create Number Value Node " << endl;
+    }
+    auto booleanValue = Open62541::Variant(false);
+    cout << "Created BOOLEAN_Value=" << booleanValue.toString() << endl;
+    cout << "is it boolean?=" << (booleanValue.get().type->typeKind == UA_DATATYPEKIND_BOOLEAN) << endl;
+
+    // Retrieve the actual data, instead of calling .toString()
+    // bool retrievedBoolValue = *(UA_Boolean*)booleanValue.get().data;
+    // cout << "retrievedBoolValue=" << retrievedBoolValue << endl;
+    // Same, but modern cast
+    // bool v = static_cast<bool>(*(UA_Boolean*)booleanValue.get().data);
+    // Add value to server node
+    Open62541::NodeId nodeBoolean(_idx, "BOOLEAN_Value");
+    if (!addVariable(Open62541::NodeId::Objects, "BOOLEAN_Value", booleanValue, nodeBoolean, Open62541::NodeId::Null)) {
+        cout << "Failed to create boolean Value Node " << endl;
     }
     //
     // Create TestMethod node
@@ -186,7 +205,7 @@ inline void SetupSignalHandlers()
     signal(SIGTERM, StopHandler);
 }
 
-int main(int  argc, char** argv)
+int main(int argc, char** argv)
 {
     int port = 4840;
     SetupSignalHandlers();

--- a/include/open62541cpp/open62541client.h
+++ b/include/open62541cpp/open62541client.h
@@ -209,7 +209,7 @@ public:
     /*!
      * \brief initialise
      */
-    void initialise()
+    void initialise(bool setDefaultConfig = true)
     {
         if (_client) {
             disconnect();
@@ -217,6 +217,9 @@ public:
             _client = nullptr;
         }
         _client = UA_Client_new();
+        if (!setDefaultConfig) {
+            return;
+        }
         if (_client) {
             UA_ClientConfig_setDefault(UA_Client_getConfig(_client));  // initalise the client structure
             UA_Client_getConfig(_client)->clientContext                  = this;
@@ -224,20 +227,6 @@ public:
             UA_Client_getConfig(_client)->subscriptionInactivityCallback = subscriptionInactivityCallback;
         }
     }
-
-    /*!
-     * \brief Initialise the client without default configuration
-     */
-    void initialiseNoConfig()
-    {
-        if (_client) {
-            disconnect();
-            UA_Client_delete(_client);
-            _client = nullptr;
-        }
-        _client = UA_Client_new();
-    }
-
     /*!
      * \brief Returns the clients default configuration if initialised
      */
@@ -591,30 +580,11 @@ public:
         \param endpointUrl
         \return true on success
     */
-    bool connect(const std::string& endpointUrl)
+    bool connect(const std::string& endpointUrl, bool init = true)
     {
-        initialise();
-        WriteLock l(_mutex);
-        if (!_client)
-            throw std::runtime_error("Null client");
-        _lastError = UA_Client_connect(_client, endpointUrl.c_str());
-        if (lastOK()) {
-            _connectionType = ConnectionType::CONNECTION;
+        if (init) {
+            initialise();
         }
-        else {
-            _connectionType = ConnectionType::NONE;
-        }
-        return lastOK();
-    }
-
-    /*!
-        \brief connect
-        \param endpointUrl
-        \return true on success
-    */
-    bool connectNoInit(const std::string& endpointUrl)
-    {
-        // initialise();
         WriteLock l(_mutex);
         if (!_client)
             throw std::runtime_error("Null client");
@@ -635,9 +605,14 @@ public:
         @param username
         @param password
         @return Indicates whether the operation succeeded or returns an error code */
-    bool connectUsername(const std::string& endpoint, const std::string& username, const std::string& password)
+    bool connectUsername(const std::string& endpoint,
+                         const std::string& username,
+                         const std::string& password,
+                         bool init = true)
     {
-        initialise();
+        if (init) {
+            initialise();
+        }
         WriteLock l(_mutex);
         if (!_client)
             throw std::runtime_error("Null client");
@@ -655,9 +630,11 @@ public:
         \param endpoint
         \return Indicates whether the operation succeeded or returns an error code
     */
-    bool connectAsync(const std::string& endpoint)
+    bool connectAsync(const std::string& endpoint, bool init = true)
     {
-        initialise();
+        if (init) {
+            initialise();
+        }
         WriteLock l(_mutex);
         if (!_client)
             throw std::runtime_error("Null client");
@@ -676,9 +653,11 @@ public:
      * \param endpoint
      * \return Indicates whether the operation succeeded or returns an error code
      */
-    bool connectSecureChannel(const std::string& endpoint)
+    bool connectSecureChannel(const std::string& endpoint, bool init = true)
     {
-        initialise();
+        if (init) {
+            initialise();
+        }
         WriteLock l(_mutex);
         if (!_client)
             throw std::runtime_error("Null client");
@@ -698,9 +677,11 @@ public:
      * \param endpoint
      * \return Indicates whether the operation succeeded or returns an error code
      */
-    bool connectSecureChannelAsync(const std::string& endpoint)
+    bool connectSecureChannelAsync(const std::string& endpoint, bool init = true)
     {
-        initialise();
+        if (init) {
+            initialise();
+        }
         WriteLock l(_mutex);
         if (!_client)
             throw std::runtime_error("Null client");
@@ -875,7 +856,7 @@ public:
         \brief NodeIdFromPath get the node id from the path of browse names in the given namespace. Tests for node
        existance \param path \param nodeId \return  true on success
     */
-    bool nodeIdFromPath(const NodeId &start, Path& path, NodeId& nodeId);
+    bool nodeIdFromPath(const NodeId& start, Path& path, NodeId& nodeId);
 
     /*!
         \brief createPath

--- a/include/open62541cpp/open62541client.h
+++ b/include/open62541cpp/open62541client.h
@@ -208,6 +208,7 @@ public:
     }
     /*!
      * \brief initialise
+     * \param setDefaultConfig Initialises the client with a default configuration
      */
     void initialise(bool setDefaultConfig = true)
     {
@@ -578,6 +579,7 @@ public:
     /*!
         \brief connect
         \param endpointUrl
+        \param init (Re)Initialises the client
         \return true on success
     */
     bool connect(const std::string& endpointUrl, bool init = true)
@@ -604,11 +606,12 @@ public:
         @param endpointURL to connect (for example "opc.tcp://localhost:16664")
         @param username
         @param password
+        @param init (Re)Initialises the client
         @return Indicates whether the operation succeeded or returns an error code */
     bool connectUsername(const std::string& endpoint,
                          const std::string& username,
                          const std::string& password,
-                         bool init = true)
+                         const bool init = true)
     {
         if (init) {
             initialise();
@@ -628,6 +631,7 @@ public:
     /*!
         \brief connectAsync
         \param endpoint
+        \param init (Re)Initialises the client
         \return Indicates whether the operation succeeded or returns an error code
     */
     bool connectAsync(const std::string& endpoint, bool init = true)
@@ -651,6 +655,7 @@ public:
     /*!
      * \brief connectSecureChannel
      * \param endpoint
+     * \param init (Re)Initialises the client
      * \return Indicates whether the operation succeeded or returns an error code
      */
     bool connectSecureChannel(const std::string& endpoint, bool init = true)
@@ -675,6 +680,7 @@ public:
     /*!
      * \brief connectSecureChannelAsync
      * \param endpoint
+     * \param init (Re)Initialises the client
      * \return Indicates whether the operation succeeded or returns an error code
      */
     bool connectSecureChannelAsync(const std::string& endpoint, bool init = true)


### PR DESCRIPTION
Modified the client functions to use default parameters
this way we can avoid duplicated code while using a custom client configuration